### PR TITLE
Pass CC and CXX environmental variables

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -614,7 +614,9 @@ async function dockerBuild(
       env.startsWith('PYO3_') ||
       env.startsWith('TARGET_') ||
       env.startsWith('CMAKE_') ||
+      env.startsWith('CC') ||
       env.startsWith('CFLAGS') ||
+      env.startsWith('CXX') ||
       env.startsWith('CXXFLAGS') ||
       env.startsWith('CPPFLAGS') ||
       env.startsWith('LDFLAGS') ||


### PR DESCRIPTION
manylinux images default to gcc. Using CC=clang and CXX=clang++ with appropriate LDFLAGS and RUSTFLAGS allows cross-language LTO of Rust, C, and C++ with LLVM and LLD.