### PR TITLE
Move before script before sccache setup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -590,15 +590,6 @@ async function dockerBuild(
       'echo "::endgroup::"'
     )
   }
-  if (sccache) {
-    commands.push(
-      'echo "::group::Install sccache"',
-      'python3 -m pip install "sccache>=0.4.0"',
-      'sccache --version',
-      'echo "::endgroup::"'
-    )
-    setupSccacheEnv()
-  }
 
   const beforeScript = getBeforeScript()
   if (beforeScript.length > 0) {
@@ -607,6 +598,16 @@ async function dockerBuild(
       ...beforeScript.split('\n'),
       'echo "::endgroup::"'
     )
+  }
+
+  if (sccache) {
+    commands.push(
+      'echo "::group::Install sccache"',
+      'python3 -m pip install "sccache>=0.4.0"',
+      'sccache --version',
+      'echo "::endgroup::"'
+    )
+    setupSccacheEnv()
   }
 
   commands.push(`maturin ${args.join(' ')}`)


### PR DESCRIPTION
Refs https://github.com/PyO3/maturin-action/issues/249

Right now this fails because the `pip` module is not available. A more comprehensive fix is likely possible, but for now just moving `before-script-linux` _before_ the sccache installation allows the user to install the `python3-pip` package.

More generally, running the before script as early as possible is a good thing, as it allows workarounds for any future problems that may arise like this.