### PR TITLE
Adds support for docker-in-docker cross platform builds

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     description: Additional Docker run options, for passing environment variables and etc.
     required: false
   host-home-mount:
-    description: Host home folder where the runner's home folder is mounted to. Used for building using Docker-in-Docker runners
+    description: Host folder where the runner's home folder is mounted to. Used for building using Docker-in-Docker runners
     required: false
   target:
     description: The --target option for cargo

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,9 @@ inputs:
   docker-options:
     description: Additional Docker run options, for passing environment variables and etc.
     required: false
+  host-home-mount:
+    description: Host home folder where the runner's home folder is mounted to. Used for building using Docker-in-Docker runners
+    required: false
   target:
     description: The --target option for cargo
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -11839,15 +11839,29 @@ async function dockerBuild(container, maturinRelease, hostHomeMount, args) {
     core.startGroup('Cleanup build scripts artifact directory');
     const debugBuildDir = path.join(targetDir, 'debug', 'build');
     if ((0, fs_1.existsSync)(debugBuildDir)) {
-        await exec.exec('sudo', ['rm', '-rf', debugBuildDir], {
-            ignoreReturnCode: true
-        });
+        if (process.env.RUNNER_ALLOW_RUNASROOT === '1') {
+            await exec.exec('rm', ['-rf', debugBuildDir], {
+                ignoreReturnCode: true
+            });
+        }
+        else {
+            await exec.exec('sudo', ['rm', '-rf', debugBuildDir], {
+                ignoreReturnCode: true
+            });
+        }
     }
     const releaseBuildDir = path.join(targetDir, 'release', 'build');
     if ((0, fs_1.existsSync)(debugBuildDir)) {
-        await exec.exec('sudo', ['rm', '-rf', releaseBuildDir], {
-            ignoreReturnCode: true
-        });
+        if (process.env.RUNNER_ALLOW_RUNASROOT === '1') {
+            await exec.exec('rm', ['-rf', releaseBuildDir], {
+                ignoreReturnCode: true
+            });
+        }
+        else {
+            await exec.exec('sudo', ['rm', '-rf', releaseBuildDir], {
+                ignoreReturnCode: true
+            });
+        }
     }
     core.endGroup();
     const dockerEnvs = [];
@@ -11900,15 +11914,29 @@ async function dockerBuild(container, maturinRelease, hostHomeMount, args) {
         core.info(`Fixing file permissions for target directory: ${targetDir}`);
         const uid = process.getuid();
         const gid = process.getgid();
-        await exec.exec('sudo', ['chown', `${uid}:${gid}`, '-R', targetDir], {
-            ignoreReturnCode: true
-        });
+        if (process.env.RUNNER_ALLOW_RUNASROOT === '1') {
+            await exec.exec('chown', [`${uid}:${gid}`, '-R', targetDir], {
+                ignoreReturnCode: true
+            });
+        }
+        else {
+            await exec.exec('sudo', ['chown', `${uid}:${gid}`, '-R', targetDir], {
+                ignoreReturnCode: true
+            });
+        }
         const outDir = getCliValue(args, '--out') || getCliValue(args, '-o');
         if (outDir && (0, fs_1.existsSync)(outDir)) {
             core.info(`Fixing file permissions for output directory: ${outDir}`);
-            await exec.exec('sudo', ['chown', `${uid}:${gid}`, '-R', outDir], {
-                ignoreReturnCode: true
-            });
+            if (process.env.RUNNER_ALLOW_RUNASROOT === '1') {
+                await exec.exec('chown', [`${uid}:${gid}`, '-R', outDir], {
+                    ignoreReturnCode: true
+                });
+            }
+            else {
+                await exec.exec('sudo', ['chown', `${uid}:${gid}`, '-R', outDir], {
+                    ignoreReturnCode: true
+                });
+            }
         }
         core.endGroup();
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@vercel/ncc": "^0.36.0",
         "eslint": "^8.26.0",
         "eslint-plugin-github": "^4.4.0",
-        "prettier": "^2.6.0"
+        "prettier": "^2.8.8"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2471,9 +2471,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
-      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -4798,9 +4798,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
-      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "@vercel/ncc": "^0.36.0",
     "eslint": "^8.26.0",
     "eslint-plugin-github": "^4.4.0",
-    "prettier": "^2.6.0"
+    "prettier": "^2.8.8"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -638,15 +638,27 @@ async function dockerBuild(
   core.startGroup('Cleanup build scripts artifact directory')
   const debugBuildDir = path.join(targetDir, 'debug', 'build')
   if (existsSync(debugBuildDir)) {
-    await exec.exec('sudo', ['rm', '-rf', debugBuildDir], {
-      ignoreReturnCode: true
-    })
+    if (process.env.RUNNER_ALLOW_RUNASROOT === '1') {
+      await exec.exec('rm', ['-rf', debugBuildDir], {
+        ignoreReturnCode: true
+      })
+    } else {
+      await exec.exec('sudo', ['rm', '-rf', debugBuildDir], {
+        ignoreReturnCode: true
+      })
+    }
   }
   const releaseBuildDir = path.join(targetDir, 'release', 'build')
   if (existsSync(debugBuildDir)) {
-    await exec.exec('sudo', ['rm', '-rf', releaseBuildDir], {
-      ignoreReturnCode: true
-    })
+    if (process.env.RUNNER_ALLOW_RUNASROOT === '1') {
+      await exec.exec('rm', ['-rf', releaseBuildDir], {
+        ignoreReturnCode: true
+      })
+    } else {
+      await exec.exec('sudo', ['rm', '-rf', releaseBuildDir], {
+        ignoreReturnCode: true
+      })
+    }
   }
   core.endGroup()
 
@@ -709,15 +721,28 @@ async function dockerBuild(
     core.info(`Fixing file permissions for target directory: ${targetDir}`)
     const uid = process.getuid()
     const gid = process.getgid()
-    await exec.exec('sudo', ['chown', `${uid}:${gid}`, '-R', targetDir], {
-      ignoreReturnCode: true
-    })
+    if (process.env.RUNNER_ALLOW_RUNASROOT === '1') {
+      await exec.exec('chown', [`${uid}:${gid}`, '-R', targetDir], {
+        ignoreReturnCode: true
+      })
+    } else {
+      await exec.exec('sudo', ['chown', `${uid}:${gid}`, '-R', targetDir], {
+        ignoreReturnCode: true
+      })
+    }
+
     const outDir = getCliValue(args, '--out') || getCliValue(args, '-o')
     if (outDir && existsSync(outDir)) {
       core.info(`Fixing file permissions for output directory: ${outDir}`)
-      await exec.exec('sudo', ['chown', `${uid}:${gid}`, '-R', outDir], {
-        ignoreReturnCode: true
-      })
+      if (process.env.RUNNER_ALLOW_RUNASROOT === '1') {
+        await exec.exec('chown', [`${uid}:${gid}`, '-R', outDir], {
+          ignoreReturnCode: true
+        })
+      } else {
+        await exec.exec('sudo', ['chown', `${uid}:${gid}`, '-R', outDir], {
+          ignoreReturnCode: true
+        })
+      }
     }
     core.endGroup()
   }


### PR DESCRIPTION
This PR includes 3 main changes:

- Adds a new input to the action called `host-home-mount`. This input, if given, will be prepended to the paths of the repository itself and the `run-maturin-action.sh` script on the left side (host side) of the volume mounts when building in docker. This tries to solve issue #265 where it is impossible to build cross platform wheels in a dockerized self-hosted runner. I'm not sure about the naming of this new input, open to new propositions.
- Changes the location of the `run-maturin-action.sh` script from the /tmp folder of the runner machine to the ~/_work/_temp folder of the runner itself stored in the RUNNER_TEMP env variable. This seems more prudent as the file gets cleaned up by the job itself and not by the host.
- Removes the calls to `sudo` when the runner is running as root already.