### PR TITLE
Revert "Ignore cffi installation error"

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -12037,9 +12037,7 @@ async function hostBuild(maturinRelease, args) {
     core.info(`Installing 'maturin' from tag '${maturinRelease}'`);
     const maturinPath = await installMaturin(maturinRelease);
     await exec.exec(maturinPath, ['--version'], { ignoreReturnCode: true });
-    await exec.exec('python3', ['-m', 'pip', 'install', 'cffi'], {
-        ignoreReturnCode: true
-    });
+    await exec.exec('python3', ['-m', 'pip', 'install', 'cffi']);
     if (IS_LINUX) {
         await exec.exec('python3', ['-m', 'pip', 'install', 'patchelf']);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -878,9 +878,7 @@ async function hostBuild(
   core.info(`Installing 'maturin' from tag '${maturinRelease}'`)
   const maturinPath = await installMaturin(maturinRelease)
   await exec.exec(maturinPath, ['--version'], {ignoreReturnCode: true})
-  await exec.exec('python3', ['-m', 'pip', 'install', 'cffi'], {
-    ignoreReturnCode: true
-  })
+  await exec.exec('python3', ['-m', 'pip', 'install', 'cffi'])
   if (IS_LINUX) {
     await exec.exec('python3', ['-m', 'pip', 'install', 'patchelf'])
   }


### PR DESCRIPTION
This reverts commit f61caa214c9839739a727618c8965ae7282c2aa3.

`cffi` now supports, and provides wheels for, Python 3.13 (https://github.com/python-cffi/cffi/releases/tag/v1.17.0), so this should work as expected on 3.13.

Tested on https://github.com/mkniewallner/mkv-playground/pull/9/files where `cffi` was [correctly installed](https://github.com/mkniewallner/mkv-playground/actions/runs/10745607209/job/29804938927):
```console
Install maturin
[...]
  Collecting cffi
    Downloading cffi-1.17.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (1.5 kB)
  Collecting pycparser (from cffi)
    Downloading pycparser-2.22-py3-none-any.whl.metadata (943 bytes)
  Downloading cffi-1.17.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (479 kB)
  Downloading pycparser-2.22-py3-none-any.whl (117 kB)
  Installing collected packages: pycparser, cffi
  Successfully installed cffi-1.17.1 pycparser-2.22
```