### PR TITLE
Updating sccache to 0.10.0 to add GHAC v2 support

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -11913,7 +11913,7 @@ async function dockerBuild(container, maturinRelease, hostHomeMount, args) {
         commands.push('echo "::group::Run before script"', ...beforeScript.split('\n'), 'echo "::endgroup::"');
     }
     if (sccache) {
-        commands.push('echo "::group::Install sccache"', 'python3 -m pip install --user "sccache>=0.4.0"', 'sccache --version', 'echo "::endgroup::"');
+        commands.push('echo "::group::Install sccache"', 'python3 -m pip install --user "sccache>=0.10.0"', 'sccache --version', 'echo "::endgroup::"');
         setupSccacheEnv();
     }
     commands.push(`maturin ${args.join(' ')}`);
@@ -12141,7 +12141,7 @@ async function hostBuild(maturinRelease, args) {
     }
     if (sccache) {
         core.startGroup('Install sccache');
-        await exec.exec('python3', ['-m', 'pip', 'install', 'sccache>=0.4.0']);
+        await exec.exec('python3', ['-m', 'pip', 'install', 'sccache>=0.10.0']);
         await exec.exec('sccache', ['--version']);
         setupSccacheEnv();
         core.endGroup();

--- a/src/index.ts
+++ b/src/index.ts
@@ -700,7 +700,7 @@ async function dockerBuild(
   if (sccache) {
     commands.push(
       'echo "::group::Install sccache"',
-      'python3 -m pip install --user "sccache>=0.4.0"',
+      'python3 -m pip install --user "sccache>=0.10.0"',
       'sccache --version',
       'echo "::endgroup::"'
     )
@@ -987,7 +987,7 @@ async function hostBuild(
   }
   if (sccache) {
     core.startGroup('Install sccache')
-    await exec.exec('python3', ['-m', 'pip', 'install', 'sccache>=0.4.0'])
+    await exec.exec('python3', ['-m', 'pip', 'install', 'sccache>=0.10.0'])
     await exec.exec('sccache', ['--version'])
     setupSccacheEnv()
     core.endGroup()


### PR DESCRIPTION
- Github moved to a new caching service which means that the older version of sccache will fail in workflows, necessitating an update to 0.10.0. See: https://gh.io/gha-cache-sunset.