### PR TITLE
ci: address lint findings, add zizmor workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,15 +10,19 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          node-version: '20'
+          persist-credentials: false
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: "20"
       - name: npm install
         run: npm install
       - name: lint JavaScript
@@ -31,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: [lint]
     env:
-      RUST_BACKTRACE: '1'
+      RUST_BACKTRACE: "1"
     strategy:
       fail-fast: ${{ !contains(github.event.pull_request.labels.*.name, 'CI-no-fail-fast') }}
       matrix:
@@ -42,13 +46,18 @@ jobs:
           - windows-latest
         toolchain: [stable, nightly]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: PyO3/maturin
           ref: main
           path: maturin
-      - uses: dtolnay/rust-toolchain@stable
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
       - name: maturin build
         uses: ./
         with:
@@ -88,7 +97,7 @@ jobs:
           rust-toolchain: ${{ matrix.toolchain }}
           args: -i python3.10 --out dist
           working-directory: maturin/test-crates/pyo3-mixed
-          manylinux: 'auto'
+          manylinux: "auto"
       - name: maturin build manylinux2014
         # No llvm-toolset-7 in arm64 manylinux image
         if: matrix.os != 'ubuntu-22.04-arm'
@@ -96,7 +105,7 @@ jobs:
         with:
           rust-toolchain: ${{ matrix.toolchain }}
           args: -m maturin/test-crates/pyo3-mixed/Cargo.toml -i python3.10 --out dist
-          manylinux: '2014'
+          manylinux: "2014"
           before-script-linux: |
             yum install -y llvm-toolset-7-clang
             source /opt/rh/llvm-toolset-7/enable
@@ -106,25 +115,25 @@ jobs:
         with:
           rust-toolchain: nightly
           args: -m maturin/test-crates/hello-world/Cargo.toml
-          manylinux: 'auto'
-          target: 'powerpc64le-unknown-linux-musl'
-      - uses: actions/setup-python@v5
+          manylinux: "auto"
+          target: "powerpc64le-unknown-linux-musl"
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
-          python-version: '3.11'
+          python-version: "3.11"
       - name: maturin build manylinux off
         uses: ./
         with:
           rust-toolchain: ${{ matrix.toolchain }}
           args: -m maturin/test-crates/pyo3-mixed/Cargo.toml -i python3.11
-          manylinux: 'off'
+          manylinux: "off"
       - name: maturin build container off
         uses: ./
         with:
           rust-toolchain: ${{ matrix.toolchain }}
           rustup-components: rustfmt
           args: -m maturin/test-crates/pyo3-mixed/Cargo.toml -i python3.11
-          manylinux: 'off'
-          container: 'off'
+          manylinux: "off"
+          container: "off"
       - name: maturin build container manylinux version
         uses: ./
         with:
@@ -133,14 +142,14 @@ jobs:
             rustfmt
             rust-std
           args: -m maturin/test-crates/pyo3-mixed/Cargo.toml -i python3.10
-          manylinux: 'auto'
-          container: '2_17'
+          manylinux: "auto"
+          container: "2_17"
       - name: maturin build --cargo-extra-args
         uses: ./
         with:
           rust-toolchain: ${{ matrix.toolchain }}
           args: -m tests/pyo3-pure/Cargo.toml --features python
-          manylinux: 'auto'
+          manylinux: "auto"
       - name: docker pull
         if: matrix.os == 'ubuntu-latest'
         run: docker pull quay.io/pypa/manylinux_2_28_x86_64:latest
@@ -152,7 +161,7 @@ jobs:
           rustup-components: rustfmt
           container: quay.io/pypa/manylinux_2_28_x86_64:latest
           args: -m maturin/test-crates/pyo3-mixed/Cargo.toml -i python3.10
-          manylinux: 'auto'
+          manylinux: "auto"
       - name: maturin build --target args
         if: matrix.os == 'ubuntu-latest'
         uses: ./
@@ -165,7 +174,7 @@ jobs:
           rust-toolchain: ${{ matrix.toolchain }}
           target: aarch64-unknown-linux-gnu
           args: -m maturin/test-crates/pyo3-pure/Cargo.toml --zig
-          manylinux: 'auto'
+          manylinux: "auto"
       - name: maturin build --zig container on
         if: matrix.os == 'ubuntu-latest'
         uses: ./
@@ -173,8 +182,8 @@ jobs:
           rust-toolchain: ${{ matrix.toolchain }}
           target: aarch64-unknown-linux-gnu
           args: -m maturin/test-crates/pyo3-pure/Cargo.toml --zig
-          manylinux: 'auto'
-          container: 'on'
+          manylinux: "auto"
+          container: "on"
       - name: maturin build --zig unsupported target
         if: matrix.os == 'ubuntu-latest'
         uses: ./
@@ -182,21 +191,21 @@ jobs:
           rust-toolchain: ${{ matrix.toolchain }}
           target: s390x-unknown-linux-gnu
           args: -m maturin/test-crates/pyo3-pure/Cargo.toml --zig
-          manylinux: 'auto'
+          manylinux: "auto"
       - name: maturin build cffi project
         uses: ./
         with:
           rust-toolchain: ${{ matrix.toolchain }}
           args: -m maturin/test-crates/cffi-pure/Cargo.toml
-          manylinux: 'auto'
+          manylinux: "auto"
       - run: cargo clean --manifest-path maturin/test-crates/pyo3-pure/Cargo.toml
       - name: maturin build with sccache
         uses: ./
         with:
           rust-toolchain: ${{ matrix.toolchain }}
           args: -m maturin/test-crates/pyo3-pure/Cargo.toml
-          manylinux: 'auto'
-          sccache: 'true'
+          manylinux: "auto"
+          sccache: "true"
 
   test-manylinux:
     name: Manylinux Test Suite
@@ -211,84 +220,87 @@ jobs:
           # - ubuntu-24.04-arm
         platform: [
             {
-              manylinux: '2014',
-              target: 'x86_64', # Test target alias
-              test-crate: 'maturin/test-crates/pyo3-mixed'
+              manylinux: "2014",
+              target: "x86_64", # Test target alias
+              test-crate: "maturin/test-crates/pyo3-mixed",
             },
             {
-              manylinux: '2_35', # no docker images
-              target: 'x86_64',
-              test-crate: 'maturin/test-crates/pyo3-mixed'
+              manylinux: "2_35", # no docker images
+              target: "x86_64",
+              test-crate: "maturin/test-crates/pyo3-mixed",
             },
             {
-              manylinux: '2014',
-              target: 'i686-unknown-linux-gnu',
-              test-crate: 'maturin/test-crates/pyo3-mixed'
+              manylinux: "2014",
+              target: "i686-unknown-linux-gnu",
+              test-crate: "maturin/test-crates/pyo3-mixed",
             },
             {
-              manylinux: '2014',
-              target: 'aarch64-unknown-linux-gnu',
-              test-crate: 'maturin/test-crates/pyo3-pure' # abi3
+              manylinux: "2014",
+              target: "aarch64-unknown-linux-gnu",
+              test-crate: "maturin/test-crates/pyo3-pure", # abi3
             },
             {
-              manylinux: '2014',
-              target: 'armv7-unknown-linux-gnueabihf',
-              test-crate: 'maturin/test-crates/pyo3-pure' # abi3
+              manylinux: "2014",
+              target: "armv7-unknown-linux-gnueabihf",
+              test-crate: "maturin/test-crates/pyo3-pure", # abi3
             },
             {
-              manylinux: '2014',
-              target: 'powerpc64le-unknown-linux-gnu',
-              test-crate: 'maturin/test-crates/pyo3-mixed'
+              manylinux: "2014",
+              target: "powerpc64le-unknown-linux-gnu",
+              test-crate: "maturin/test-crates/pyo3-mixed",
             },
             {
-              manylinux: 'manylinux_2_28',
-              target: 'aarch64-unknown-linux-gnu',
-              test-crate: 'maturin/test-crates/pyo3-mixed'
+              manylinux: "manylinux_2_28",
+              target: "aarch64-unknown-linux-gnu",
+              test-crate: "maturin/test-crates/pyo3-mixed",
             },
             {
-              manylinux: 'manylinux2014',
-              target: 's390x',
-              test-crate: 'maturin/test-crates/pyo3-mixed'
+              manylinux: "manylinux2014",
+              target: "s390x",
+              test-crate: "maturin/test-crates/pyo3-mixed",
             },
             {
-              manylinux: 'manylinux_2_31',
-              target: 'riscv64gc-unknown-linux-gnu',
-              test-crate: 'maturin/test-crates/pyo3-mixed'
+              manylinux: "manylinux_2_31",
+              target: "riscv64gc-unknown-linux-gnu",
+              test-crate: "maturin/test-crates/pyo3-mixed",
             },
             {
-              manylinux: 'manylinux_2_36',
-              target: 'loongarch64-unknown-linux-gnu',
-              test-crate: 'maturin/test-crates/pyo3-mixed'
+              manylinux: "manylinux_2_36",
+              target: "loongarch64-unknown-linux-gnu",
+              test-crate: "maturin/test-crates/pyo3-mixed",
             },
             {
-              manylinux: 'auto',
-              target: 'x86_64-unknown-linux-musl', # MUSL
-              test-crate: 'maturin/test-crates/hello-world' # binary
+              manylinux: "auto",
+              target: "x86_64-unknown-linux-musl", # MUSL
+              test-crate: "maturin/test-crates/hello-world", # binary
             },
             {
-              manylinux: 'musllinux_1_1',
-              target: 'x86_64',
-              test-crate: 'maturin/test-crates/pyo3-pure'
+              manylinux: "musllinux_1_1",
+              target: "x86_64",
+              test-crate: "maturin/test-crates/pyo3-pure",
             },
             {
-              manylinux: 'musllinux_1_2',
-              target: 'x86_64-unknown-linux-musl', # MUSL
-              test-crate: 'maturin/test-crates/hello-world' # binary
-            }
+              manylinux: "musllinux_1_2",
+              target: "x86_64-unknown-linux-musl", # MUSL
+              test-crate: "maturin/test-crates/hello-world", # binary
+            },
           ]
         toolchain: [stable, nightly]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: PyO3/maturin
           path: maturin
+          persist-credentials: false
       - name: Set up QEMU
         uses: dbhi/qus/action@main
       - name: maturin build
         uses: ./
         env:
-          RUST_BACKTRACE: '1'
+          RUST_BACKTRACE: "1"
         with:
           container: ${{ matrix.platform.container }}
           # Test docker-options
@@ -305,7 +317,7 @@ jobs:
       - name: maturin build rust-toolchain
         uses: ./
         env:
-          RUST_BACKTRACE: '1'
+          RUST_BACKTRACE: "1"
         with:
           container: ${{ matrix.platform.container }}
           args: -m ${{ matrix.platform.test-crate }}/Cargo.toml -i python3.8
@@ -319,7 +331,7 @@ jobs:
       - name: maturin build rust-toolchain.toml
         uses: ./
         env:
-          RUST_BACKTRACE: '1'
+          RUST_BACKTRACE: "1"
         with:
           container: ${{ matrix.platform.container }}
           args: -m ${{ matrix.platform.test-crate }}/Cargo.toml -i python3.8
@@ -336,7 +348,7 @@ jobs:
       - name: maturin build rust-toolchain with toml content
         uses: ./
         env:
-          RUST_BACKTRACE: '1'
+          RUST_BACKTRACE: "1"
         with:
           container: ${{ matrix.platform.container }}
           args: -m ${{ matrix.platform.test-crate }}/Cargo.toml -i python3.8

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -6,13 +6,19 @@ on:
     # Run every day at 1:00
     - cron: '0 1 * * *'
 
+permissions: {}
+
 jobs:
   update:
     name: Update Versions Manifest
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # for PR creation
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        persist-credentials: false
+    - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       with:
         python-version: "3.10"
     - name: Install requirements
@@ -22,7 +28,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: python generate-versions-manifest.py
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v7
+      uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
       with:
         branch: update-versions-manifest
         delete-branch: true

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,26 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # for uploading results to the Security tab
+      contents: read # only needed for private repos
+      actions: read # only needed for private repos
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@e673c3917a1aef3c65c972347ed84ccd013ecda4 # v0.2.0


### PR DESCRIPTION
Hi there!

First, thanks a ton for creating and maintaining `maturin-action` -- I use it both personally and professionally and I'm a huge fan of it (and grateful for your maintenance).

I'm filing this with a bunch of relatively small security fixes. These fixes were identified by [zizmor](https://docs.zizmor.sh), which I maintain. I don't believe that any of these are immediately exploitable, but I believe they would be good to address as a matter of defense-in-depth 🙂 

To summarize:

1. I've hash-pinned almost of the current `uses:` -- this makes the CI more hermetic, and makes it less likely that a security or reliability issue gets introduced in via a tag mutation. The one exception to this is `dbhi/qus/action@main`, which can't be pinned since it's on `main` and there's no (recent) version tag to select instead. Ideally this would be coordinated with the upstream for a a pinnable tag; I'd be happy to help coordinate that.
2. I've added persist-credentials: false to as many actions/checkout usages as possible -- this eliminates an implicitly persisted credential that GitHub Actions adds by default, which the overwhelming majority of workflows don't need.
3. I've added a zizmor.yml workflow that'll run zizmor on every PR and push; it's integrated into GitHub's "Advanced Security" so that you'll get alerts on PRs that introduce potential issues. However, this is only if you want continuous scanning here; if you'd prefer to not have another thing in your CI, I'm happy to remove this step!