### PR TITLE
ci: pin dbhi/qus/action to a specific commit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -296,7 +296,7 @@ jobs:
           path: maturin
           persist-credentials: false
       - name: Set up QEMU
-        uses: dbhi/qus/action@main
+        uses: dbhi/qus/action@f79aa71b04f5b1bfc98769edbf9a7a10659708fe # main
       - name: maturin build
         uses: ./
         env:


### PR DESCRIPTION
Follow-on from #373.

This repository appears to lack recent tags, so what I've done is pin to the latest commit on main (which is itself two years old at this time).