### PR TITLE
add maturinArch() for architecture check, improve riscv64 musllinux support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -286,6 +286,11 @@ jobs:
               manylinux: 'musllinux_1_2',
               target: 'x86_64-unknown-linux-musl', # MUSL
               test-crate: 'maturin/test-crates/hello-world' # binary
+            },
+            {
+              manylinux: 'musllinux_1_2',
+              target: 'riscv64gc-unknown-linux-musl', # MUSL
+              test-crate: 'maturin/test-crates/hello-world' # binary
             }
           ]
         toolchain: [stable, nightly]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -309,6 +309,7 @@ jobs:
         uses: ./
         env:
           RUST_BACKTRACE: '1'
+          CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_MUSL_RUSTFLAGS: -C target-feature=+crt-static
         with:
           container: ${{ matrix.platform.container }}
           # Test docker-options
@@ -326,6 +327,7 @@ jobs:
         uses: ./
         env:
           RUST_BACKTRACE: '1'
+          CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_MUSL_RUSTFLAGS: -C target-feature=+crt-static
         with:
           container: ${{ matrix.platform.container }}
           args: -m ${{ matrix.platform.test-crate }}/Cargo.toml -i python3.10
@@ -340,6 +342,7 @@ jobs:
         uses: ./
         env:
           RUST_BACKTRACE: '1'
+          CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_MUSL_RUSTFLAGS: -C target-feature=+crt-static
         with:
           container: ${{ matrix.platform.container }}
           args: -m ${{ matrix.platform.test-crate }}/Cargo.toml -i python3.10
@@ -357,6 +360,7 @@ jobs:
         uses: ./
         env:
           RUST_BACKTRACE: '1'
+          CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_MUSL_RUSTFLAGS: -C target-feature=+crt-static
         with:
           container: ${{ matrix.platform.container }}
           args: -m ${{ matrix.platform.test-crate }}/Cargo.toml -i python3.10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -317,7 +317,7 @@ jobs:
             -e RUNNER_OS
           rust-toolchain: ${{ matrix.toolchain }}
           working-directory: ${{ matrix.platform.test-crate }}
-          args: -i python3.9
+          args: -i python3.10
           manylinux: ${{ matrix.platform.manylinux }}
           target: ${{ matrix.platform.target }}
       - name: setup rust-toolchain
@@ -328,7 +328,7 @@ jobs:
           RUST_BACKTRACE: '1'
         with:
           container: ${{ matrix.platform.container }}
-          args: -m ${{ matrix.platform.test-crate }}/Cargo.toml -i python3.9
+          args: -m ${{ matrix.platform.test-crate }}/Cargo.toml -i python3.10
           manylinux: ${{ matrix.platform.manylinux }}
           target: ${{ matrix.platform.target }}
       - name: setup rust-toolchain.toml
@@ -342,7 +342,7 @@ jobs:
           RUST_BACKTRACE: '1'
         with:
           container: ${{ matrix.platform.container }}
-          args: -m ${{ matrix.platform.test-crate }}/Cargo.toml -i python3.9
+          args: -m ${{ matrix.platform.test-crate }}/Cargo.toml -i python3.10
           manylinux: ${{ matrix.platform.manylinux }}
           target: ${{ matrix.platform.target }}
       - name: setup rust-toolchain with toml content
@@ -359,7 +359,7 @@ jobs:
           RUST_BACKTRACE: '1'
         with:
           container: ${{ matrix.platform.container }}
-          args: -m ${{ matrix.platform.test-crate }}/Cargo.toml -i python3.9
+          args: -m ${{ matrix.platform.test-crate }}/Cargo.toml -i python3.10
           manylinux: ${{ matrix.platform.manylinux }}
           target: ${{ matrix.platform.target }}
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -48548,10 +48548,22 @@ async function findVersion(args) {
     }
     return version;
 }
+function maturinArch() {
+    switch (process.arch) {
+        case 'x64':
+            return 'x86_64';
+        case 'arm64':
+            return 'aarch64';
+        case 'riscv64':
+            return 'riscv64gc';
+        default:
+            return process.arch; // TODO handle more arches
+    }
+}
 async function downloadMaturin(tag) {
     let name;
     let zip = false;
-    const arch = process.arch === 'arm64' ? 'aarch64' : 'x86_64';
+    const arch = maturinArch();
     if (src_IS_WINDOWS) {
         name = `maturin-${arch}-pc-windows-msvc.zip`;
         zip = true;
@@ -48677,18 +48689,7 @@ async function dockerBuild(container, maturinRelease, hostHomeMount, args) {
     else {
         info(`Using existing ${image} Docker image`);
     }
-    const arch = (() => {
-        switch (process.arch) {
-            case 'x64':
-                return 'x86_64';
-            case 'arm64':
-                return 'aarch64';
-            case 'riscv64':
-                return 'riscv64gc';
-            default:
-                return process.arch;
-        }
-    })();
+    const arch = maturinArch();
     const url = maturinRelease === 'latest'
         ? `https://github.com/PyO3/maturin/releases/latest/download/maturin-${arch}-unknown-linux-musl.tar.gz`
         : `https://github.com/PyO3/maturin/releases/download/${maturinRelease}/maturin-${arch}-unknown-linux-musl.tar.gz`;

--- a/generate-versions-manifest.py
+++ b/generate-versions-manifest.py
@@ -6,8 +6,8 @@
 # ]
 # ///
 import hashlib
-import os
 import json
+import os
 import sys
 
 import requests
@@ -108,8 +108,7 @@ def fetch_releases(page=1, per_page=50):
             )
 
         version = release["name"] or release["tag_name"]
-        if version.startswith("v"):
-            version = version[1:]
+        version = version.removeprefix("v")
         yield {
             "version": version,
             "stable": not (release["prerelease"] or release["draft"]),

--- a/src/index.ts
+++ b/src/index.ts
@@ -558,13 +558,29 @@ async function findVersion(args: string[]): Promise<string> {
 }
 
 /**
+ * Map Node's process.arch to the arch component of a maturin release asset name
+ */
+function maturinArch(): string {
+  switch (process.arch) {
+    case 'x64':
+      return 'x86_64'
+    case 'arm64':
+      return 'aarch64'
+    case 'riscv64':
+      return 'riscv64gc'
+    default:
+      return process.arch // TODO handle more arches
+  }
+}
+
+/**
  * Download and return the path to an executable maturin tool
  * @param tag string The tag to download
  */
 async function downloadMaturin(tag: string): Promise<string> {
   let name: string
   let zip = false
-  const arch = process.arch === 'arm64' ? 'aarch64' : 'x86_64'
+  const arch = maturinArch()
   if (IS_WINDOWS) {
     name = `maturin-${arch}-pc-windows-msvc.zip`
     zip = true
@@ -717,18 +733,7 @@ async function dockerBuild(
     core.info(`Using existing ${image} Docker image`)
   }
 
-  const arch = (() => {
-    switch (process.arch) {
-      case 'x64':
-        return 'x86_64'
-      case 'arm64':
-        return 'aarch64'
-      case 'riscv64':
-        return 'riscv64gc'
-      default:
-        return process.arch // TODO handle more arches
-    }
-  })()
+  const arch = maturinArch()
   const url =
     maturinRelease === 'latest'
       ? `https://github.com/PyO3/maturin/releases/latest/download/maturin-${arch}-unknown-linux-musl.tar.gz`

--- a/src/index.ts
+++ b/src/index.ts
@@ -231,6 +231,10 @@ const DEFAULT_CONTAINERS: Record<
     'riscv64gc-unknown-linux-gnu': {
       auto: 'quay.io/pypa/manylinux_2_39_riscv64:latest',
       '2_39': 'quay.io/pypa/manylinux_2_39_riscv64:latest'
+    },
+    'riscv64gc-unknown-linux-musl': {
+      auto: 'quay.io/pypa/musllinux_1_2_riscv64:latest',
+      '1_2': 'quay.io/pypa/manylinux_1_2_riscv64:latest',
     }
   }
 }


### PR DESCRIPTION
This PR is a general response to issues building musllinux wheels for the riscv64gc case. While working on https://github.com/ringsaturn/go-cities.json/pull/145 I noticed that the host arch mapping was wrong when trying to build for riscv64. The first four patches try to address this, while the latter three address what appear to be pre-existing issues encountered while validating that everything still worked OK on my fork: https://github.com/threexc/maturin-action/pull/1

In the process, I've also submitted: https://github.com/rust-cross/rust-musl-cross/pull/251

Note that the `windows-11-arm` case seems to be breaking - something to do with the zig linking process. I'm not sure what to do there. The rest should be OK.